### PR TITLE
Use the generic SF for TCP tests (if an IB device has multiple net interfaces), and print the full result for RDMA tests

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -32,11 +32,12 @@ change_mtu() {
     elif [ "${LINK_TYPE}" -eq 32 ]; then
         MTU=4092
     fi
-    ssh "${CLIENT_TRUSTED}" "sudo bash -c 'echo ${MTU} > /sys/class/infiniband/${CLIENT_DEVICE}/device/net/*/mtu'"
-    ssh "${SERVER_TRUSTED}" "sudo bash -c 'echo ${MTU} > /sys/class/infiniband/${SERVER_DEVICE}/device/net/*/mtu'"
-    CURR_MTU="$(ssh "${CLIENT_TRUSTED}" "cat /sys/class/infiniband/${CLIENT_DEVICE}/device/net/*/mtu")"
+    # TODO: Support multiple client/server devices (when TCP test will support them)
+    ssh "${CLIENT_TRUSTED}" "sudo bash -c 'echo ${MTU} > /sys/class/infiniband/${CLIENT_DEVICE}/device/net/${CLIENT_NETDEV}/mtu'"
+    ssh "${SERVER_TRUSTED}" "sudo bash -c 'echo ${MTU} > /sys/class/infiniband/${SERVER_DEVICE}/device/net/${SERVER_NETDEV}/mtu'"
+    CURR_MTU="$(ssh "${CLIENT_TRUSTED}" "cat /sys/class/infiniband/${CLIENT_DEVICE}/device/net/${CLIENT_NETDEV}/mtu")"
     ((CURR_MTU == MTU)) || log 'Warning, MTU was not configured correctly on Client'
-    CURR_MTU="$(ssh "${SERVER_TRUSTED}" "cat /sys/class/infiniband/${SERVER_DEVICE}/device/net/*/mtu")"
+    CURR_MTU="$(ssh "${SERVER_TRUSTED}" "cat /sys/class/infiniband/${SERVER_DEVICE}/device/net/${SERVER_NETDEV}/mtu")"
     ((CURR_MTU == MTU)) || log 'Warning, MTU was not configured correctly on Server'
 }
 
@@ -117,7 +118,7 @@ get_server_client_ips_and_ifs() {
             CLIENT_IP=()
             for cdev in "${client_devices[@]}"
             do
-                CLIENT_NETDEV+=("$(ssh "${CLIENT_TRUSTED}" "ls /sys/class/infiniband/${cdev}/device/net")")
+                CLIENT_NETDEV+=("$(ssh "${CLIENT_TRUSTED}" "ls -1 /sys/class/infiniband/${cdev}/device/net | head -1")")
                 [ -n "${CLIENT_NETDEV[${#CLIENT_NETDEV[@]}-1]}" ] ||
                     fatal "Can't find a client net device associated with the IB device '${cdev}'."
                 CLIENT_IP+=("$(ssh "${CLIENT_TRUSTED}" "ip a sh ${CLIENT_NETDEV[${#CLIENT_NETDEV[@]}-1]}" | grep -ioP '(?<=inet )\d+\.\d+\.\d+\.\d+' | xargs | tr ' ' ',')")
@@ -127,7 +128,7 @@ get_server_client_ips_and_ifs() {
             done
             ;;
         *)
-            CLIENT_NETDEV="$(ssh "${CLIENT_TRUSTED}" "ls /sys/class/infiniband/${CLIENT_DEVICE}/device/net")"
+            CLIENT_NETDEV="$(ssh "${CLIENT_TRUSTED}" "ls -1 /sys/class/infiniband/${CLIENT_DEVICE}/device/net | head -1")"
             [ -n "${CLIENT_NETDEV}" ] ||
                 fatal "Can't find client net device. Did you mean to specify IB device as '${CLIENT_DEVICE}'?"
 
@@ -143,7 +144,7 @@ get_server_client_ips_and_ifs() {
             SERVER_IP=()
             for sdev in "${server_devices[@]}"
             do
-                SERVER_NETDEV+=("$(ssh "${SERVER_TRUSTED}" "ls /sys/class/infiniband/${sdev}/device/net")")
+                SERVER_NETDEV+=("$(ssh "${SERVER_TRUSTED}" "ls -1 /sys/class/infiniband/${sdev}/device/net | head -1")")
                 [ -n "${SERVER_NETDEV[${#SERVER_NETDEV[@]}-1]}" ] ||
                     fatal "Can't find a server net device associated with the IB device '${sdev}'."
                 SERVER_IP+=("$(ssh "${SERVER_TRUSTED}" "ip a sh ${SERVER_NETDEV[${#SERVER_NETDEV[@]}-1]}" | grep -ioP '(?<=inet )\d+\.\d+\.\d+\.\d+' | xargs | tr ' ' ',')")
@@ -153,7 +154,7 @@ get_server_client_ips_and_ifs() {
             done
             ;;
         *)
-            SERVER_NETDEV="$(ssh "${SERVER_TRUSTED}" "ls /sys/class/infiniband/${SERVER_DEVICE}/device/net")"
+            SERVER_NETDEV="$(ssh "${SERVER_TRUSTED}" "ls -1 /sys/class/infiniband/${SERVER_DEVICE}/device/net | head -1")"
             [ -n "${SERVER_NETDEV}" ] ||
                 fatal "Can't find server net device. Did you mean to specify IB device as '${SERVER_DEVICE}'?"
 

--- a/ngc_ipsec_full_offload_tcp_test.sh
+++ b/ngc_ipsec_full_offload_tcp_test.sh
@@ -44,7 +44,7 @@ mtu_sizes=()
 if [ -z "${MTU_SIZE}" ]; then
     for dev in "${client_devices[@]}"
     do
-        net_name="$(ssh "${CLIENT_TRUSTED}" "ls -1 /sys/class/infiniband/${dev}/device/net/ | tail -1")"
+        net_name="$(ssh "${CLIENT_TRUSTED}" "ls -1 /sys/class/infiniband/${dev}/device/net/ | head -1")"
         mtu_sizes+=("$(ssh "${CLIENT_TRUSTED}" "ip a show ${net_name} | awk '/mtu/{print \$5}'")")
     done
     MTU_SIZE="$(get_min_val ${mtu_sizes[@]})"

--- a/ngc_rdma_test.sh
+++ b/ngc_rdma_test.sh
@@ -213,8 +213,8 @@ for TEST in ib_write_bw ib_read_bw ib_send_bw ; do
 
     if $PASS
     then
-        log "NGC ${TEST} Passed for devices: ${SERVER_DEVICES[@]} <-> ${CLIENT_DEVICES[@]}"
+        log "NGC ${TEST} Passed for devices: ${SERVER_DEVICES[*]} <-> ${CLIENT_DEVICES[*]}"
     else
-        log "NGC ${TEST} Failed for devices: ${SERVER_DEVICES[@]} <-> ${CLIENT_DEVICES[@]}"
+        log "NGC ${TEST} Failed for devices: ${SERVER_DEVICES[*]} <-> ${CLIENT_DEVICES[*]}"
     fi
 done

--- a/ngc_rdma_test.sh
+++ b/ngc_rdma_test.sh
@@ -98,6 +98,7 @@ run_perftest(){
         BW2=$(ssh "${CLIENT_TRUSTED}" "sudo awk -F'[:,]' '/BW_average/{print \$2}' /tmp/perftest_${CLIENT_DEVICES[1]}.json | cut -d. -f1 | xargs")
         #Make sure that there is a valid BW
         check_if_number "$BW2" || PASS=false
+        log "Device ${CLIENT_DEVICES[1]} reached ${BW2} Gb/s (max possible: $((port_rate2 * 2)) Gb/s)"
         if [[ $BW2 -lt ${BW_PASS_RATE2} ]] && [[ $PKT_SIZE -eq $REPORT_ON_SIZE ]]
         then
             log "Device ${CLIENT_DEVICES[1]} didn't reach pass bw rate of ${BW_PASS_RATE} Gb/s"
@@ -110,6 +111,7 @@ run_perftest(){
     BW=$(ssh "${CLIENT_TRUSTED}" "sudo awk -F'[:,]' '/BW_average/{print \$2}' /tmp/perftest_${CLIENT_DEVICES[0]}.json | cut -d. -f1 | xargs")
     #Make sure that there is a valid BW
     check_if_number "$BW" || PASS=false
+    log "Device ${CLIENT_DEVICES[0]} reached ${BW} Gb/s (max possible: $((port_rate * 2)) Gb/s)"
     if [[ $BW -lt ${BW_PASS_RATE} ]]
     then
         log "Device ${CLIENT_DEVICES[0]} didn't reach pass bw rate of ${BW_PASS_RATE} Gb/s"

--- a/ngc_tcp_test.sh
+++ b/ngc_tcp_test.sh
@@ -65,7 +65,7 @@ SERVER_CORE_USAGES_FILE="/tmp/ngc_server_core_usages.log"
 ssh "${CLIENT_TRUSTED}" sudo systemctl stop irqbalance
 ssh "${SERVER_TRUSTED}" sudo systemctl stop irqbalance
 
-LINK_TYPE="$(ssh "${CLIENT_TRUSTED}" "cat /sys/class/infiniband/${CLIENT_DEVICE}/device/net/*/type")"
+LINK_TYPE="$(ssh "${CLIENT_TRUSTED}" "cat /sys/class/infiniband/${CLIENT_DEVICE}/device/net/${CLIENT_NETDEV}/type")"
 # Increase MTU to maximum per link type
 [ "${CHANGE_MTU}" != "CHANGE" ] || change_mtu
 


### PR DESCRIPTION
Please see the individual commit messages for details.