### PR TITLE
rdma: Allow checking all the supported connection types

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bidirectional tests. Pass criterion is 90% of the port link speed.
 ```
 ./ngc_rdma_test.sh <client hostname/ip> <client ib device>[,<client ib device2>] \
     <server hostname/ip> <server ib device>[,<server ib device2>] [--use_cuda] \
-    [--qp=<num of QPs, default: 4>]
+    [--qp=<num of QPs, default: 4>] [--all_connection_types]
 ```
 
 ## TCP test


### PR DESCRIPTION
Add the capability to perform the RDMA tests on all the supported connection types for each test, according to the listing in the test's 'help' output.

The SRD (Scalable Reliable Datagram) type is excluded, as some versions of libibverbs do not include it.