### PR TITLE
TCP: Verify that hosts don't have unpopulated NUMA nodes + small refactoring

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -202,6 +202,14 @@ prep_for_tune_and_iperf_test() {
     ssh "${CLIENT_TRUSTED}" pkill iperf3
     ssh "${SERVER_TRUSTED}" pkill iperf3
 
+    find_empty_numas=( "numactl" "-H" "|" "awk"
+                       "'/node [0-9]+ size:/{print \$4}'" "|"
+                       "grep" "-q" "'^0$'" )
+    ! ssh "${CLIENT_TRUSTED}" "${find_empty_numas[*]}" ||
+        fatal "${CLIENT_TRUSTED} has empty NUMAs - please verify your BIOS/SMT settings."
+    ! ssh "${SERVER_TRUSTED}" "${find_empty_numas[*]}" ||
+        fatal "${SERVER_TRUSTED} has empty NUMAs - please verify your BIOS/SMT settings."
+
     CLIENT_NUMA_NODE="$(ssh "${CLIENT_TRUSTED}" "cat /sys/class/infiniband/${CLIENT_DEVICE}/device/numa_node")"
     ((CLIENT_NUMA_NODE != -1)) || CLIENT_NUMA_NODE="0"
     SERVER_NUMA_NODE="$(ssh "${SERVER_TRUSTED}" "cat /sys/class/infiniband/${SERVER_DEVICE}/device/numa_node")"

--- a/common.sh
+++ b/common.sh
@@ -222,7 +222,7 @@ prep_for_tune_and_iperf_test() {
     TCP_PORT_ID="$(echo "${CLIENT_DEVICE}" | cut -d '_' -f 2)"
     TCP_PORT_ADDITION=$((TCP_PORT_ID * 100))
     BASE_TCP_PORT=$((5200 + TCP_PORT_ADDITION))
-    NUMACTL_HW=("numactl" "--hardware" "|" "grep" "-v" "node")
+    NUMACTL_HW=("numactl" "-H" "|" "grep" "-v" "node")
     NUM_SOCKETS_CMD=("lscpu" "|" "grep" "'Socket'" "|" "cut" "-d':'" "-f2")
     NUM_NUMAS_CMD=("lscpu" "|" "grep" "'NUMA node(s)'" "|" "cut" "-d':'" "-f2")
 


### PR DESCRIPTION
Currently, runs fail on hosts where some NUMA nodes are unpopulated. However a scenario where some nodes are _actually_ unpopulated is quite rare. Instead it's very likely that some nodes seem to be unpopulated
because of BIOS misconfiguration. So for now, just fail the run with an informative message in cases of such a misconfiguration, instead of letting it continue and fail with a bunch of cryptic messages.

Plus a small refactoring.