### PR TITLE
functionality to pick connection types with a list

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -883,7 +883,7 @@ collect_BW() {
                 failed_tcp_test=true
             fi
             #echo "Server side(act as client for full duplex ) ${SERVER_DEVICES[dev_idx]} report throughput of ${S_BW}Gb/s"
-            echo -e "${pref}Throughput ${CLIENT_TRUSTED}:${CLIENT_DEVICES[dev_idx]} <->  ${SERVER_TRUSTED}:${SERVER_DEVICES[dev_idx]} :  ${BW}Gb/s <-> ${S_BW}Gb/s${suffix}"
+            echo -e "${pref}Throughput ${CLIENT_TRUSTED}:${CLIENT_DEVICES[dev_idx]} <->  ${SERVER_TRUSTED}:${SERVER_DEVICES[dev_idx]} :  ${BW}Gb/s <-> ${S_BW}Gb/s${suffix} / ${port_rate}Gb/s${suffix}"
             dupBW=$(echo "$S_BW + $BW" | bc)
             echo "Full duplex: ${dupBW}Gb/s"
             totalBW=$(echo "$totalBW + $dupBW" | bc)


### PR DESCRIPTION
Added a flag to pick connection types with a list. (rdma)

usage: 
./ngc_rdma_test <client> <clientadapters> <server> <serveradapters> --conn=UC,RC,XRC
only commas, no spaces (same convention as mlx adapters)

edge cases:
- Using both --all_connection_types and --conn together, would just enter the condition in line 280 and skip the "else" in 284 that handles --conn. 
- different connection types may be available (line 43), in future will append use get_perftest_connect_options() function on all tests to append all connection types into a list. 
