### PR TITLE
RDMA: Set default QPs optimization     

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bidirectional tests. Pass criterion is 90% of the port link speed.
 ```
 ./ngc_rdma_test.sh <client hostname/ip> <client ib device>[,<client ib device2>] \
     <server hostname/ip> <server ib device>[,<server ib device2>] [--use_cuda] \
-    [--qp=<num of QPs, default: 4>] [--all_connection_types | --conn=<list of connection types>] [--tests=<list of ib perftests>]
+    [--qp=<num of QPs, default: total 4>] [--all_connection_types | --conn=<list of connection types>] [--tests=<list of ib perftests>] [--bw_message_size_list=<list of message sizes>] [--lat_message_size_list=<list of message sizes>]
 ```
 
 ## TCP test

--- a/ngc_rdma_test.sh
+++ b/ngc_rdma_test.sh
@@ -108,6 +108,8 @@ CLIENT_DEVICES=(${2//,/ })
 SERVER_TRUSTED="${3}"
 SERVER_DEVICES=(${4//,/ })
 NUM_CONNECTIONS=${#CLIENT_DEVICES[@]}
+(( 1 <= NUM_CONNECTIONS )) && (( NUM_CONNECTIONS <= 2 )) ||
+    fatal "Number of connections ${NUM_CONNECTIONS} is too high."
 (( default_qps /= NUM_CONNECTIONS )) ||
     fatal "You need more QPs for the specified number of connections"
 [ -n "${QPS}" ] || QPS="${default_qps}"

--- a/ngc_rdma_test.sh
+++ b/ngc_rdma_test.sh
@@ -108,6 +108,8 @@ CLIENT_DEVICES=(${2//,/ })
 SERVER_TRUSTED="${3}"
 SERVER_DEVICES=(${4//,/ })
 NUM_CONNECTIONS=${#CLIENT_DEVICES[@]}
+(( default_qps /= NUM_CONNECTIONS )) ||
+    fatal "You need more QPs for the specified number of connections"
 [ -n "${QPS}" ] || QPS="${default_qps}"
 (( QPS <= max_qps )) || fatal "Max allowed QPs are ${max_qps}."
 #Defaults are not using cuda, set params as empty string


### PR DESCRIPTION
Configuration of the default QP settings as follows:                                                                                                                                                                                         - For a single port, set to 2 QPs.                                                                                                                                                                                                           - For two or more ports, set to 4 QPs. 