### PR TITLE
Remove ngc keyword from search results

### DIFF
--- a/ngc_rdma_wrapper.sh
+++ b/ngc_rdma_wrapper.sh
@@ -160,7 +160,7 @@ results() {
         lowercase_line=$(echo "$line" | tr '[:upper:]' '[:lower:]')
         if [[ $lowercase_line == *"passed"* ]]; then
             echo -e "${GREEN}$line${NC}"
-        elif [[ $lowercase_line == *"ngc"* && $lowercase_line == *"failed"* ]]; then
+        elif [[ $lowercase_line == *"failed"* ]]; then
             echo -e "${RED}$line${NC}"
         elif [[ $lowercase_line == *"cuda on"* ]]; then
             echo ""


### PR DESCRIPTION
Since it was refactored on ngc_rdma_test.sh, I removed parsing for the line "NGC"