### PR TITLE
rdma: Format command arrays as actual arrays and not strings

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -962,7 +962,9 @@ run_perftest_servers() {
             server_cuda="--use_cuda=${CUDA_INDEX}"
             fi
         extra_server_args_str="${extra_server_args[*]//%%QPS%%/${server_QPS[dev_idx]}}"
-        cmd_arr=("taskset" "-c" "${core}" "${TEST}" "-d" "${SERVER_DEVICES[dev_idx]}" "-s" "${message_size}" "-D 30" "-p $prt" "-F" "${conn_type_cmd[*]}" "${extra_server_args_str}" "${server_cuda}")
+        cmd_arr=("taskset" "-c" "${core}" "${TEST}" "-d" "${SERVER_DEVICES[dev_idx]}"
+                 "-s" "${message_size}" "-D" "30" "-p" "${prt}" "-F"
+                 "${conn_type_cmd[*]}" "${extra_server_args_str}" "${server_cuda}")
         ssh "${SERVER_TRUSTED}" "${cmd_arr[*]} >> /dev/null &" &
         log "INFO: run ${TEST} server on ${SERVER_TRUSTED}: ${cmd_arr[*]}"
     done
@@ -990,7 +992,12 @@ run_perftest_clients() {
             fi
         ip_i=${SERVER_IPS[dev_idx]}
         extra_client_args_str="${extra_client_args[*]//%%QPS%%/${client_QPS[dev_idx]}}"
-        cmd_arr=("taskset -c $core ${TEST} -d ${CLIENT_DEVICES[dev_idx]} -D 30 ${SERVER_TRUSTED} -s ${message_size} -p $prt -F ${conn_type_cmd[*]} ${extra_client_args_str} ${client_cuda} --out_json --out_json_file=/tmp/perftest_${CLIENT_DEVICES[dev_idx]}.json &")
+        cmd_arr=("taskset" "-c" "${core}" "${TEST}" "-d" "${CLIENT_DEVICES[dev_idx]}"
+                 "-D" "30" "${SERVER_TRUSTED}" "-s" "${message_size}" "-p" "${prt}"
+                 "-F" "${conn_type_cmd[*]}" "${extra_client_args_str}"
+                 "${client_cuda}" "--out_json"
+                 "--out_json_file=/tmp/perftest_${CLIENT_DEVICES[dev_idx]}.json"
+                 "&")
         ssh "${CLIENT_TRUSTED}" "${cmd_arr[*]}" & declare ${bg_pid}=$!
         log "INFO: run ${TEST} client on ${CLIENT_TRUSTED}: ${cmd_arr[*]}"
     done


### PR DESCRIPTION
Format command arrays as actual arrays and not strings, also make shorter lines for readability.