### PR TITLE
rdma: Add pass/fail criteria for latency tests + refactoring

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -27,7 +27,7 @@ check_connection() {
 check_if_number(){
     local re num
     num=$1
-    re='^[0-9]+$'
+    re='^[0-9]+(\.[0-9]+)?$'
     [[ $num =~ $re ]] || return 1
 }
 

--- a/common.sh
+++ b/common.sh
@@ -1012,9 +1012,9 @@ run_perftest_clients() {
             port_rate=$(get_port_rate "${CLIENT_TRUSTED}" "${CLIENT_DEVICES[dev_idx]}")
             BW_PASS_RATE="$(awk "BEGIN {printf \"%.0f\n\", ${multiplier}*0.9*${port_rate}}")"
             BW=$(ssh "${CLIENT_TRUSTED}" "sudo awk -F'[:,]' '/BW_average/{print \$2}' /tmp/perftest_${CLIENT_DEVICES[dev_idx]}.json | cut -d. -f1 | xargs")
-            check_if_number "$BW" || PASS=false
+            check_if_number "${BW}" || PASS=false
             log "Device ${CLIENT_DEVICES[dev_idx]} reached ${BW} Gb/s (max possible: $((port_rate * multiplier)) Gb/s)"
-            if [[ $BW -lt ${BW_PASS_RATE} ]]
+            if [[ ${BW} -lt ${BW_PASS_RATE} ]]
             then
                 log "Device ${CLIENT_DEVICES[dev_idx]} didn't reach pass bw rate of ${BW_PASS_RATE} Gb/s"
                 PASS=false

--- a/ngc_rdma_test.sh
+++ b/ngc_rdma_test.sh
@@ -243,13 +243,10 @@ for TEST in "${TESTS[@]}"; do
             run_perftest_servers
             sleep 2
             run_perftest_clients
-            if [ "${bw_test}" = "true" ]
-            then
-                [ "${CONN_TYPE}" = "default" ] &&
-                    logstring[1]="-" || logstring[1]="(connection type: ${CONN_TYPE})"
-                [ "${PASS}" = true ] && logstring[2]="Passed" || logstring[2]="Failed"
-                log "${logstring[*]}"
-            fi
+            [ "${CONN_TYPE}" = "default" ] &&
+                logstring[1]="-" || logstring[1]="(connection type: ${CONN_TYPE})"
+            [ "${PASS}" = true ] && logstring[2]="Passed" || logstring[2]="Failed"
+            log "${logstring[*]}"
         done
     done
 done

--- a/ngc_rdma_test.sh
+++ b/ngc_rdma_test.sh
@@ -228,7 +228,7 @@ for TEST in "${TESTS[@]}"; do
             fatal "${TEST} - test not supported."
             ;;
     esac
-     
+
     for CONN_TYPE in "${connection_types[@]}"
     do
         if [[ "${TEST}" == *_lat* ]]; then


### PR DESCRIPTION
Even though pass/fail criteria for latency tests are hard to determine (they depend greatly on the fabric in-between, etc.) adding arbitrary criteria of 2.5 μs for write & send tests, and 4.5 μs for read tests, as such numbers that if the performance is worse than them, there certainly is an issue somewhere.

While at it - small style fixes.

This solves #84 .