### PR TITLE
IPsec full-offload: Flush tc rules

### DIFF
--- a/ipsec_full_offload_setup.sh
+++ b/ipsec_full_offload_setup.sh
@@ -84,6 +84,7 @@ set_ipsec_rules() {
     local out_reqid=$8
     local offload_type=$9
 
+    ssh "${client}" "sudo ovs-appctl exit --cleanup"
     ssh "${client}" "sudo /opt/mellanox/iproute2/sbin/ip xfrm state add src ${local_IP}/24 dst ${remote_IP}/24 proto esp spi ${out_reqid} reqid ${out_reqid} mode transport aead 'rfc4106(gcm(aes))' ${out_key} 128 ${offload_type} dev ${device} dir out sel src ${local_IP}/24 dst ${remote_IP}/24"
     ssh "${client}" "sudo /opt/mellanox/iproute2/sbin/ip xfrm state add src ${remote_IP}/24 dst ${local_IP}/24 proto esp spi ${in_reqid} reqid ${in_reqid} mode transport aead 'rfc4106(gcm(aes))' ${in_key} 128 ${offload_type} dev ${device} dir in sel src ${remote_IP}/24 dst ${local_IP}/24"
     ssh "${client}" "sudo /opt/mellanox/iproute2/sbin/ip xfrm policy add src ${local_IP}/24 dst ${remote_IP}/24 ${offload_type} dev ${device} dir out tmpl src ${local_IP}/24 dst ${remote_IP}/24 proto esp reqid ${out_reqid} mode transport"


### PR DESCRIPTION
ipsec_full_offload_setup: Removing current tc rules prior to establishing xfrm rules.