### PR TITLE
README: Require a minimum perftest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * jq
 * iperf3 version >= 3.5
 * sysstat
+* perftest version >= 4.5-0.11 (if running RDMA tests)
 * nvidia-utils (if running RDMA test with CUDA)
 
 ## Access requirements


### PR DESCRIPTION
Require a minimum perftest version, as previous versions did not support JSON output.

This resolves #106.