### PR TITLE
Standartize log messages and output them to systemd journal

### DIFF
--- a/ngc_rdma_test.sh
+++ b/ngc_rdma_test.sh
@@ -304,8 +304,14 @@ for TEST in "${TESTS[@]}"; do
             run_perftest_clients
             [ "${CONN_TYPE}" = "default" ] &&
                 logstring[1]="-" || logstring[1]="(connection type: ${CONN_TYPE})"
-            [ "${PASS}" = true ] && logstring[2]="Passed" || logstring[2]="Failed"
-            log "${logstring[*]}"
+            if [ "${PASS}" = true ]
+            then
+                logstring[2]="Passed"
+                log "${logstring[*]}" RESULT_PASS
+            else
+                logstring[2]="Failed"
+                log "${logstring[*]}" RESULT_FAIL
+            fi
         done
     done
 done

--- a/ngc_tcp_test.sh
+++ b/ngc_tcp_test.sh
@@ -90,7 +90,7 @@ SERVER_CORE_USAGES_FILE="/tmp/ngc_server_core_usages.log"
 
 if [ "$DISABLE_RO" = true ]
 then
-    echo -e "${ORANGE}WARN: apply WA for Sapphire system - please apply the following tuning in BIOS - Socket Configuration > IIO Configuration > Socket# Configuration > PE# Restore RO Write Perf > Enabled instead of using this WA${NC}"
+    log "Apply WA for Sapphire system - please apply the following tuning in BIOS - Socket Configuration > IIO Configuration > Socket# Configuration > PE# Restore RO Write Perf > Enabled instead of using this WA" WARNING
     sleep 2
 fi
 
@@ -169,16 +169,16 @@ opt_proc=$((min_l<MAX_PROC ? min_l : MAX_PROC))
 read -ra CORES_ARRAY <<< $(get_cores_for_devices $1 $2 $3 $4 $((opt_proc+2)))
 #NUM_CORES_PER_DEVICE will be the actual cores that need to be used
 NUM_CORES_PER_DEVICE=$(( ${#CORES_ARRAY[@]}/(${#CLIENT_DEVICES[@]}*2) ))
-log "INFO: Number of cores per device to be used is $NUM_CORES_PER_DEVICE, if duplex then half of them will act as servers and half as clients."
+log "Number of cores per device to be used is $NUM_CORES_PER_DEVICE, if duplex then half of them will act as servers and half as clients."
 
 log "${CORES_ARRAY[*]}"
 
 if [ "$DUPLEX" = true ]
 then
-    log "INFO: Running Full duplex."
+    log "Running Full duplex."
     NUM_INST=$((NUM_CORES_PER_DEVICE/2))
 else
-    log "INFO: Running half duplex."
+    log "Running half duplex."
     NUM_INST=${NUM_CORES_PER_DEVICE}
 fi
 


### PR DESCRIPTION
Use log for all messages, and standartize colors and prefixes. Log to system journal in addition to the terminal

Output logs to the system journal, additionally to stdout/stderr:

* To read the logs:
Live, advancing:       `journalctl -b -f -t ngc_multinode_perf`
From the current boot: `journalctl -b -t ngc_multinode_perf`
From any time:         `journalctl -t ngc_multinode_perf`

This introduces a dependency on systemd, which is reasonable in 2024.