### PR TITLE
Support different usernames on client/server than on the runner machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Will configure IPsec full offload on both client and server DPU, and then run a 
 
 ## IPsec crypto offload test
 
-* Relevant for new HCAs (ConnectX-6 DX and above). 
+* Relevant for new HCAs (ConnectX-6 DX and above).
 
 Will configure IPsec crypto offload on both client and server, run TCP test,
 and remove IPsec configuration.

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ bidirectional tests. Pass criterion is 90% of the port link speed.
 ### Usage:
 
 ```
-./ngc_rdma_test.sh <client hostname/ip> <client ib device>[,<client ib device2>] \
-    <server hostname/ip> <server ib device>[,<server ib device2>] [--use_cuda] \
+./ngc_rdma_test.sh [<client username>@]<client hostname/ip> <client ib device>[,<client ib device2>] \
+    [<server username>@]<server hostname/ip> <server ib device>[,<server ib device2>] [--use_cuda] \
     [--qp=<num of QPs, default: total 4>] \
     [--all_connection_types | --conn=<list of connection types>] \
     [--tests=<list of ib perftests>] \
@@ -61,7 +61,7 @@ each device.
 ### Usage:
 
 ```
-./ngc_rdma_wrapper.sh <client hostname/ip> <server hostname/ip> \
+./ngc_rdma_wrapper.sh [<client username>@]<client hostname/ip> [<server username>@]<server hostname/ip> \
     [--with_cuda, default: without cuda] \
     [--cuda_only] \
     [--write] \
@@ -89,7 +89,7 @@ aggregated throughput is in Gb/s.
 ### Usage:
 
 ```
-./ngc_tcp_test.sh <client hostname/ip> <client ib device> <server hostname/ip> \
+./ngc_tcp_test.sh [<client username>@]<client hostname/ip> <client ib device> [<server username>@]<server hostname/ip> \
     <server ib device> [--duplex=<"HALF" (default) or "FULL">] \
     [--change_mtu=<"CHANGE" (default) or "DONT_CHANGE">] \
     [--duration=<in seconds, default: 120>]
@@ -106,8 +106,8 @@ Will configure IPsec full offload on both client and server DPU, and then run a 
 ### Usage:
 
 ```
-./ngc_ipsec_full_offload_tcp_test.sh <client hostname/ip> <client ib device> \
-    <server hostname/ip> <server ib device> <client bluefield hostname/ip> \
+./ngc_ipsec_full_offload_tcp_test.sh [<client username>@]<client hostname/ip> <client ib device> \
+    [<server username>@]<server hostname/ip> <server ib device> <client bluefield hostname/ip> \
     <server bluefield hostname/ip> [--mtu=<mtu size>] \
     [--duration=<in seconds, default: 120>]
 ```
@@ -122,8 +122,8 @@ and remove IPsec configuration.
 ### Usage:
 
 ```
-./ngc_ipsec_crypto_offload_tcp_test.sh <client hostname/ip> <client ib device> \
-    <server hostname/ip> <server ib device> <number of tunnels>
+./ngc_ipsec_crypto_offload_tcp_test.sh [<client username>@]<client hostname/ip> <client ib device> \
+    [<server username>@]<server hostname/ip> <server ib device> <number of tunnels>
 ```
 
 * The number of tunnels should not exceed the number of IPs configured on the NICs.

--- a/common.sh
+++ b/common.sh
@@ -510,7 +510,7 @@ get_numa_nodes_array() {
     for dev in "${RDMA_DEVICES[@]}"
     do
         if ssh ${IP} "test -e /sys/class/infiniband/${dev}/device/numa_node"; then
-            NUMA_NODE=`ssh ${IP} cat /sys/class/infiniband/${dev}/device/numa_node`
+            NUMA_NODE=$(ssh ${IP} cat /sys/class/infiniband/${dev}/device/numa_node)
             if [[ $NUMA_NODE == "-1" ]]; then
                 NUMA_NODE="0"
             fi
@@ -860,7 +860,7 @@ run_iperf_servers() {
     for ((; dev_idx<NUM_DEVS; dev_idx++))
     do
         local OFFSET_S=$((dev_idx*NUM_CORES_PER_DEVICE ))
-        for i in `seq 0 $((NUM_INST-1))`; do
+        for i in $(seq 0 $((NUM_INST-1))); do
             sleep 0.1
             index=$((i+OFFSET_S))
             core="${CORES_ARRAY[index]}"
@@ -873,7 +873,7 @@ run_iperf_servers() {
         if [ "$DUPLEX"  = "true" ]
         then
             local OFFSET_C=$((dev_idx*NUM_CORES_PER_DEVICE+ NUM_DEVS*NUM_CORES_PER_DEVICE))
-            for i in `seq 0 $((NUM_INST-1))`
+            for i in $(seq 0 $((NUM_INST-1)))
             do
                 sleep 0.1
                 index=$(( i+OFFSET_C ))
@@ -903,7 +903,7 @@ run_iperf_clients() {
     for ((; dev_idx<NUM_DEVS; dev_idx++))
     do
         local OFFSET_S=$((dev_idx*NUM_CORES_PER_DEVICE + NUM_DEVS*NUM_CORES_PER_DEVICE + DUPLEX_OFFSET))
-        for i in `seq 0 $((NUM_INST-1))`; do
+        for i in $(seq 0 $((NUM_INST-1))); do
             sleep 0.1
             index=$((i+OFFSET_S))
             core="${CORES_ARRAY[index]}"
@@ -922,7 +922,7 @@ run_iperf_clients() {
         if [ "$DUPLEX"  = true ]
         then
             local OFFSET_C=$((dev_idx*NUM_CORES_PER_DEVICE+ DUPLEX_OFFSET))
-            for i in `seq 0 $((NUM_INST-1))`
+            for i in $(seq 0 $((NUM_INST-1)))
             do
                 sleep 0.1
                 index=$(( i+OFFSET_C ))
@@ -1098,10 +1098,10 @@ get_bandwidth_from_combined_files(){
     local file_prefix=$3
     local out="/tmp/iperf3_${tag}_${TIME_STAMP}.log"
     ssh ${S} "cat ${file_prefix}*" > ${out}
-    throughput_bits=`cat ${out} | grep sum_sent -A7 | grep bits_per_second | tr "," " " | awk '{ SUM+=$NF } END { print SUM } '`
+    throughput_bits=$(cat ${out} | grep sum_sent -A7 | grep bits_per_second | tr "," " " | awk '{ SUM+=$NF } END { print SUM } ')
     #convert to bytes
-    BITS=`printf '%.0f' $throughput_bits`
-    throughput_Gbytes=`bc -l <<< "scale=2; $BITS/1000000000"`
+    BITS=$(printf '%.0f' $throughput_bits)
+    throughput_Gbytes=$(bc -l <<< "scale=2; $BITS/1000000000")
     echo ${throughput_Gbytes}
 }
 
@@ -1164,12 +1164,13 @@ collect_BW() {
         return 0
     fi
 }
+
 print_stats(){
     server=$1
     file="/tmp/ngc_tcp_core_usages_${TIME_STAMP}.txt"
     log "Server: ${server#*@}"
     ssh "${server}" "awk '{print \$2 \"\t\" \$5}' $file"
     usages=( $(ssh "${server}" "awk 'NR>1 {print \$5}' $file") )
-    total_active_avarage=`get_average ${usages[@]}`
+    total_active_avarage=$(get_average ${usages[@]})
     paste <(echo "${server#*@}: Overall Active: $total_active_avarage") <(echo "Overall All cores: ") <(ssh ${server} "awk 'NR==2 {print \$5}' ${file}")
 }

--- a/ngc_ipsec_crypto_offload_tcp_test.sh
+++ b/ngc_ipsec_crypto_offload_tcp_test.sh
@@ -3,7 +3,7 @@
 # Owner: dorko@nvidia.com
 
 if (( $# != 5 )); then
-    echo "usage: $0 <client trusted ip> <client ib device> <server trusted ip> <server ib device> <number of tunnels>"
+    echo "usage: $0 [<client username>@]<client trusted ip> <client ib device> [<server username>@]<server trusted ip> <server ib device> <number of tunnels>"
     exit 1
 fi
 

--- a/ngc_rdma_test.sh
+++ b/ngc_rdma_test.sh
@@ -111,7 +111,7 @@ Run RDMA test
 * Passwordless sudo root access is required from the SSH'ing user.
 * Dependencies which need to be installed: numctl, perftest.
 
-Syntax: $0 <client hostname> <client ib device1>[,client ib device2] <server hostname> <server ib device1>[,server ib device2] [--use_cuda] [--qp=<num of QPs>] [--all_connection_types | --conn=<list of connection types>] [ --tests=<list of ib perftests>] [--message-size-list=<list of message sizes>] [--ipsec]
+Syntax: $0 [<client username>@]<client hostname> <client ib device1>[,client ib device2] [<server username>@]<server hostname> <server ib device1>[,server ib device2] [--use_cuda] [--qp=<num of QPs>] [--all_connection_types | --conn=<list of connection types>] [ --tests=<list of ib perftests>] [--message-size-list=<list of message sizes>] [--ipsec]
 
 Options:
 	--use_cuda : add this flag to run BW perftest benchamrks on GPUs

--- a/ngc_rdma_test.sh
+++ b/ngc_rdma_test.sh
@@ -241,7 +241,7 @@ then
         ovs_configure ${REMOTE_BF[index]} ${REMOTE_BF_device[index]} ${representor2} "${remote_IP}" "${local_IP}" "${index}"
     done
     for ((index1=0; index1<NUM_DEVS; index1++))
-    do 
+    do
         set_ip ${CLIENT_TRUSTED} ${CLIENT_NETDEVS[index1]} "${CLIENT_IPS[index1]}/${CLIENT_IPS_MASK[index1]}" ${SERVER_TRUSTED} ${SERVER_NETDEVS[index1]} "${SERVER_IPS[index1]}/${SERVER_IPS_MASK[index1]}"
     done
 fi
@@ -332,7 +332,7 @@ then
         update_mlnx_bf_conf_revert ${LOCAL_BF[index]}
         update_mlnx_bf_conf_revert ${REMOTE_BF[index]}
         for ((index1=0; index1<NUM_DEVS; index1++))
-        do 
+        do
             set_ip ${CLIENT_TRUSTED} ${CLIENT_NETDEVS[index1]} "${CLIENT_IPS[index1]}/${CLIENT_IPS_MASK[index1]}" ${SERVER_TRUSTED} ${SERVER_NETDEVS[index1]} "${SERVER_IPS[index1]}/${SERVER_IPS_MASK[index1]}"
         done
     done

--- a/ngc_tcp_test.sh
+++ b/ngc_tcp_test.sh
@@ -6,7 +6,7 @@ set -eE
 trap 'printf "Error in function %s, on line %d.\n" "${FUNCNAME[1]}" "${BASH_LINENO[0]}"' ERR
 
 if (($# < 4)); then
-    echo "usage: $0 <client trusted ip> <client ib device>[,client ib device2] <server trusted ip> <server ib device>[,server ib device2] [--duplex=<'HALF','FULL'>] [--change_mtu=<'CHANGE','DONT_CHANGE'>] [--duration=<sec>] [--max_proc=<number>]"
+    echo "usage: $0 [<client username>@]<client trusted ip> <client ib device>[,client ib device2] [<server username>@]<server trusted ip> <server ib device>[,server ib device2] [--duplex=<'HALF','FULL'>] [--change_mtu=<'CHANGE','DONT_CHANGE'>] [--duration=<sec>] [--max_proc=<number>]"
     echo "		   duplex - options: HALF,FULL, default: HALF"
     echo "		   change_mtu - options: CHANGE,DONT_CHANGE, default: CHANGE"
     echo "		   duration - time in seconds, default: 120"

--- a/ngc_tcp_test.sh
+++ b/ngc_tcp_test.sh
@@ -156,7 +156,7 @@ then
         ovs_configure ${REMOTE_BF[index]} ${REMOTE_BF_device[index]} ${representor2} "${remote_IP}" "${local_IP}" "${index}"
     done
     for ((index1=0; index1<NUM_DEVS; index1++))
-    do 
+    do
         set_ip ${CLIENT_TRUSTED} ${CLIENT_NETDEVS[index1]} "${CLIENT_IPS[index1]}/${CLIENT_IPS_MASK[index1]}" ${SERVER_TRUSTED} ${SERVER_NETDEVS[index1]} "${SERVER_IPS[index1]}/${SERVER_IPS_MASK[index1]}"
     done
 fi
@@ -229,7 +229,7 @@ then
         update_mlnx_bf_conf_revert ${LOCAL_BF[index]}
         update_mlnx_bf_conf_revert ${REMOTE_BF[index]}
         for ((index1=0; index1<NUM_DEVS; index1++))
-        do 
+        do
             set_ip ${CLIENT_TRUSTED} ${CLIENT_NETDEVS[index1]} "${CLIENT_IPS[index1]}/${CLIENT_IPS_MASK[index1]}" ${SERVER_TRUSTED} ${SERVER_NETDEVS[index1]} "${SERVER_IPS[index1]}/${SERVER_IPS_MASK[index1]}"
         done
     done


### PR DESCRIPTION
Support different usernames on client/server than on the runner machine and on each other.

While at it, use the new style Bash command substitution everywhere, and remove trailing whitespaces.