### PR TITLE
common: Adapt to changes in mlnx-sf

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -231,7 +231,7 @@ get_netdev_from_ibdev() {
     netdev="$(ls -1 "/sys/class/infiniband/${ibdev}/device/net" | head -1)"
     if mlnx-sf -h &> /dev/null
     then
-        sfdev="$(mlnx-sf -ja show | jq -r --arg SF "${netdev}" '.[] | select(.netdev==$SF) | .sf_netdev' 2>/dev/null)"
+        sfdev="$(mlnx-sf -ja show | sed 's/^No SF device found$/{}/' | jq -r --arg SF "${netdev}" '.[] | select(.netdev==$SF) | .sf_netdev' 2>/dev/null)"
     fi
     [ -z "${sfdev}" ] || netdev="${sfdev}"
     printf "%s" "${netdev}"


### PR DESCRIPTION
In recent versions of mlnx-sf (a part of the mlnx-tools package) if no SF devices are found, `mlnx-sf -ja show` returns a string `No SF device found` instead of an empty JSON (`{}`). This commit mitigates this behavior.