### PR TITLE
TCP: Bind to specific interface for testing

### DIFF
--- a/run_iperf3_clients.sh
+++ b/run_iperf3_clients.sh
@@ -9,12 +9,13 @@ IP=$6
 BASE_TCP_PORT=$7
 THREADS=$8
 TIME=$9
+BIND_IP="${10}"
 
 for P in $(seq 0 $((PROC-1)))
     do ( sleep 0.1
          numactl --cpunodebind=$(((NUMA_NODE+P)%LOGICAL_NUMA_PER_SOCKET+BASE_NUMA)) \
              numactl --physcpubind=+$((P/LOGICAL_NUMA_PER_SOCKET)) \
-             iperf3 -Z -N -i 60 -c "${IP}"  -P "${THREADS}"  -t "${TIME}" \
+             iperf3 -Z -N -i 60 -c "${IP}" -B "${BIND_IP}" -P "${THREADS}"  -t "${TIME}" \
              -p $((BASE_TCP_PORT+P)) -J &
         )
     done | sudo tee "${RESULT_FILE}"

--- a/run_iperf3_servers.sh
+++ b/run_iperf3_servers.sh
@@ -5,6 +5,7 @@ NUMA_NODE=$2
 LOGICAL_NUMA_PER_SOCKET=$3
 BASE_NUMA=$4
 BASE_TCP_PORT=$5
+BIND_IP="${6}"
 
 
 
@@ -12,6 +13,6 @@ for P in $(seq 0 $((PROC-1)))
     do ( sleep 0.1
          numactl --cpunodebind=$(((NUMA_NODE+P)%LOGICAL_NUMA_PER_SOCKET+BASE_NUMA)) \
              numactl --physcpubind=+$((P/LOGICAL_NUMA_PER_SOCKET)) \
-             iperf3 -s -p $((BASE_TCP_PORT+P)) --one-off &
+             iperf3 -s -B "${BIND_IP}" -p $((BASE_TCP_PORT+P)) --one-off &
         )
     done


### PR DESCRIPTION
Bind to specific interface for testing, to avoid rogue traffic on other interfaces, if they exist.