### PR TITLE
Remove abuse of passwordless sudo, be more strict with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Firstly, generate a passwordless SSH key (_e.g._ using `ssh-keygen`) and copy it
     * Make sure that your non-root user is able to use `sudo` (is in administrative group, such as `sudo` or `wheel`, or is mentioned directly in the sudoers file).
     * Make sure that your non-root user is able to use `sudo` either without a password at all (for example, this configuration in the sudoers file will do, assuming your user is a member of a group named `sudo`: `%sudo ALL=(ALL:ALL) NOPASSWD: ALL`) or, for a more granular approach, the following line can be used, allowing the non-root user to run only the needed binaries without a password:
         ```
-        %sudo ALL=(ALL) ALL, NOPASSWD: /usr/bin/bash,/usr/sbin/ip,/opt/mellanox/iproute2/sbin/ip,/usr/bin/mlxprivhost,/usr/bin/mst,/usr/bin/systemctl,/usr/sbin/ethtool,/usr/sbin/set_irq_affinity_cpulist.sh,/usr/bin/tee,/usr/bin/numactl,/usr/bin/awk,/usr/bin/taskset,/usr/bin/setpci,/usr/bin/rm -f /tmp/*
+        %sudo ALL=(ALL) ALL, NOPASSWD: /usr/sbin/ip,/opt/mellanox/iproute2/sbin/ip,/usr/bin/mlxprivhost,/usr/bin/mst,/usr/bin/systemctl restart openvswitch-switch.service,/usr/bin/systemctl stop irqbalance.service,/usr/sbin/ethtool,/usr/sbin/set_irq_affinity_cpulist.sh,/usr/bin/tee /sys/class/net/*,/usr/bin/tee /proc/sys/net/core/rps_sock_flow_entries,/usr/bin/numactl,/usr/bin/awk,/usr/bin/taskset,/usr/bin/setpci,/usr/bin/rm -f /tmp/*
         ```
 
 ## RDMA test

--- a/ipsec_full_offload_setup.sh
+++ b/ipsec_full_offload_setup.sh
@@ -22,11 +22,9 @@ update_mlnx_bf_conf() {
     if [ -z "$current_setting" ]; then
         echo "$ipsec_setting" >> "$mlnx_conf"
         echo "Added $ipsec_setting to $mlnx_conf"
-        ssh "$client" "sudo systemctl stop mlx-regex; /etc/init.d/openibd restart; systemctl restart mlx-regex"
     elif [ "$current_setting" = "no" ]; then
         ssh "$client" "sudo sed -i 's/IPSEC_FULL_OFFLOAD=\"no\"/IPSEC_FULL_OFFLOAD=\"yes\"/' \"$mlnx_conf\""
         echo "Changed IPSEC_FULL_OFFLOAD setting to 'yes' in $mlnx_conf on $client"
-        ssh "$client" "sudo systemctl stop mlx-regex; /etc/init.d/openibd restart; systemctl restart mlx-regex"
     else
         echo "IPSEC_FULL_OFFLOAD is already set to 'yes' in $mlnx_conf on $client"
     fi
@@ -41,11 +39,9 @@ update_mlnx_bf_conf_revert() {
     if [ -z "$current_setting" ]; then
         echo "$ipsec_setting" >> "$mlnx_conf"
         echo "Added $ipsec_setting to $mlnx_conf"
-        ssh "$client" "sudo systemctl stop mlx-regex; /etc/init.d/openibd restart; systemctl restart mlx-regex"
     elif [ "$current_setting" = "yes" ]; then
         ssh "$client" "sudo sed -i 's/IPSEC_FULL_OFFLOAD=\"yes\"/IPSEC_FULL_OFFLOAD=\"no\"/' \"$mlnx_conf\""
         echo "Changed IPSEC_FULL_OFFLOAD setting to 'no' in $mlnx_conf on $client"
-        ssh "$client" "sudo systemctl stop mlx-regex; /etc/init.d/openibd restart; systemctl restart mlx-regex"
     else
         echo "IPSEC_FULL_OFFLOAD is already set to 'no' in $mlnx_conf on $client"
     fi


### PR DESCRIPTION
Remove abuse of passwordless sudo, be more strict with it.

While at it, remove outdated unit handling (mlx-regex).

This resolves #143.